### PR TITLE
Cherry-pick 0506323c2b323b3a87435baaa5ea49a7441f43b6 from https://git…

### DIFF
--- a/roles/configure-mirrors/handlers/main.yaml
+++ b/roles/configure-mirrors/handlers/main.yaml
@@ -3,6 +3,9 @@
 - name: Update apt cache
   become: yes
   command: apt-get update
+  # ANSIBLE0006: ignore, since we cannot use the apt module
+  tags:
+    - skip_ansible_lint
 
 - name: Update dnf cache
   become: yes

--- a/roles/emit-job-header/tasks/main.yaml
+++ b/roles/emit-job-header/tasks/main.yaml
@@ -1,4 +1,5 @@
-- include_role:
+- name: Set zuul-log-path fact
+  include_role:
     name: set-zuul-log-path-fact
 
 - debug:

--- a/roles/mirror-workspace-git-repos/tasks/main.yaml
+++ b/roles/mirror-workspace-git-repos/tasks/main.yaml
@@ -1,7 +1,9 @@
 - name: Allow pushing to non-bare repo
-  command: "git config --local receive.denyCurrentBranch ignore"
-  args:
-    chdir: "{{ ansible_user_dir }}/{{ item.src_dir}}"
+  git_config:
+    name: receive.denyCurrentBranch ignore
+    value: ignore
+    scope: local
+    repo: "{{ ansible_user_dir }}/{{ item.src_dir}}"
   with_items: "{{ zuul.projects }}"
 
 - name: Synchronize src repos to workspace directory
@@ -10,6 +12,10 @@
     chdir: "{{ zuul.executor.work_root }}/{{ item.src_dir }}"
   with_items: "{{ zuul.projects }}"
   delegate_to: localhost
+  # ANSIBLE0006: Skip linting since it triggers on the "git" command,
+  # but push is not supported by ansible git module.
+  tags:
+    - skip_ansible_lint
 
 - name: Determine local HEAD
   shell: "git status |head -1 |awk '{ print $NF }'"
@@ -18,6 +24,10 @@
   with_items: "{{ zuul.projects }}"
   delegate_to: localhost
   register: statuses
+  # ANSIBLE0006: Skip linting since it triggers on the "git" command,
+  # but status is not supported by ansible git module.
+  tags:
+    - skip_ansible_lint
 
 # Do this as a multi-line shell so that we can do the loop once
 - name: Update remote repository state correctly
@@ -33,3 +43,7 @@
   with_together:
     - "{{ zuul.projects }}"
     - "{{ statuses.results }}"
+  # ANSIBLE0006: Skip linting since it triggers on the "git" command,
+  # but we prefer the shell above
+  tags:
+    - skip_ansible_lint

--- a/roles/upload-logs/tasks/main.yaml
+++ b/roles/upload-logs/tasks/main.yaml
@@ -1,4 +1,5 @@
-- include_role:
+- name: Set zuul-log-path fact
+  include_role:
     name: set-zuul-log-path-fact
 
 - name: Create log directories


### PR DESCRIPTION
…hub.com/openstack-infra/zuul-jobs fixing lint errors.

Ansible linting fixes

Fix a few problems noticed when using this in project-config:
* Ignore apt-get warning in configure-mirrors
* All tasks should be named in upload-logs, emit-job-header
* use git_config in mirror-workspace-git-repos
* Ignore git warnings in mirror-workspace-git-repos

Change-Id: Ibcdc8d5a42fb081b5faa0cc89460e4cf88d369ba