### PR TITLE
fix pydistutils error

### DIFF
--- a/roles/configure-mirrors/templates/.pydistutils.cfg.j2
+++ b/roles/configure-mirrors/templates/.pydistutils.cfg.j2
@@ -1,4 +1,3 @@
 # {{ ansible_managed }}
 [easy_install]
 index_url = {{ pypi_mirror }}
-allow_hosts = {{ mirror_fqdn }}


### PR DESCRIPTION
On ubuntu-xenial, prevent tox error:
File "/usr/local/lib/python3.5/dist-packages/setuptools/installer.py", line 74, in fetch_build_egg
raise DistutilsError('the `allow-hosts` option is not supported '
'when using pip to install requirements.')


https://contrail-jws.atlassian.net/browse/CE-3027